### PR TITLE
Keep a local reference to the process name to avoid memory corruption

### DIFF
--- a/include/osquery/logger.h
+++ b/include/osquery/logger.h
@@ -151,6 +151,20 @@ class LoggerPlugin : public Plugin {
     return false;
   }
 
+  /**
+   * @brief Set the process name.
+   */
+  void setName(const std::string& name) {
+    name_ = name;
+  }
+
+  /**
+   * @brief Get the process name.
+   */
+  const std::string& name() const {
+    return name_;
+  }
+
  protected:
   /** @brief Virtual method which should implement custom logging.
    *
@@ -216,6 +230,9 @@ class LoggerPlugin : public Plugin {
   virtual Status logEvent(const std::string& s) {
     return Status(1, "Not enabled");
   }
+
+ private:
+  std::string name_;
 };
 
 /// Set the verbose mode, changes Glog's sinking logic and will affect plugins.

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -412,7 +412,8 @@ Status LoggerPlugin::call(const PluginRequest& request,
     return this->logSnapshot(request.at("snapshot"));
   } else if (request.count("init") > 0) {
     deserializeIntermediateLog(request, intermediate_logs);
-    this->init(request.at("init"), intermediate_logs);
+    this->setName(request.at("init"));
+    this->init(this->name(), intermediate_logs);
     return Status(0);
   } else if (request.count("status") > 0) {
     deserializeIntermediateLog(request, intermediate_logs);


### PR DESCRIPTION
r: @bknox, @dje