### PR TITLE
prometheus_metrics: initial table spec and table implmentation

### DIFF
--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -89,6 +89,8 @@ if(NOT WINDOWS)
   ADD_OSQUERY_LINK_ADDITIONAL("crypto")
   ADD_OSQUERY_LINK_ADDITIONAL("libpthread")
 
+  ADD_OSQUERY_LINK_CORE("curl")
+  ADD_OSQUERY_LINK_CORE("ssl")
   ADD_OSQUERY_LINK_CORE("crypto")
 
   # Linenoise will be used when compiling osqueryi.

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -23,6 +23,7 @@
 #include <Windows.h>
 #include <signal.h>
 #else
+#include <curl/curl.h>
 #include <unistd.h>
 #endif
 
@@ -253,6 +254,8 @@ void Initializer::platformSetup() {
     ::CoUninitialize();
   }
 #else
+  // libcurl global initialization
+  curl_global_init(CURL_GLOBAL_ALL);
 #endif
 }
 
@@ -261,6 +264,7 @@ void Initializer::platformTeardown() {
 #ifdef WIN32
   ::CoUninitialize();
 #else
+  curl_global_cleanup();
 #endif
 }
 

--- a/osquery/tables/applications/posix/prometheus_metrics.cpp
+++ b/osquery/tables/applications/posix/prometheus_metrics.cpp
@@ -1,0 +1,240 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <chrono>
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <curl/curl.h>
+
+#include <osquery/config.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+#include <osquery/tables/applications/posix/prometheus_metrics_utils.h>
+
+namespace osquery {
+namespace tables {
+const std::string col_target_name = "target_name";
+const std::string col_metric = "metric_name";
+const std::string col_value = "metric_value";
+const std::string col_timestamp = "timestamp";
+
+struct retData {
+  int size;
+  std::string content;
+};
+
+#ifdef _WIN32
+inline void wait(int x) {
+  Sleep(x);
+}
+#else
+/* Portable sleep for platforms other than Windows. */
+inline void wait(int x) {
+  struct timeval wait = {0, (x)*1000};
+  (void)select(0, NULL, NULL, NULL, &wait);
+}
+#endif
+
+size_t writeCallback(void* contents, size_t size, size_t nmemb, void* userp) {
+  size_t realSize = size * nmemb;
+  struct retData* payload = (struct retData*)userp;
+
+  char* cContents = (char*)contents;
+  for (size_t i = 0; i < realSize; i++) {
+    payload->content.push_back(cContents[i]);
+  }
+
+  payload->size += realSize;
+
+  return realSize;
+}
+
+class PrometheusMetrics {
+ public:
+  PrometheusMetrics(std::vector<std::string> urls, long timeoutDurationS = 1L)
+      : m_urls(urls),
+        m_multiHandle(curl_multi_init()),
+        m_timeoutDurtionS(timeoutDurationS) {}
+
+  ~PrometheusMetrics() {
+    curl_multi_cleanup(m_multiHandle);
+  }
+
+  QueryData& queryPrometheusTargets();
+
+ private:
+  QueryData m_rows;
+  std::vector<std::string> m_urls;
+  CURLM* m_multiHandle;
+  long m_timeoutDurtionS;
+
+  std::map<std::string, retData*> scrapeTargets();
+  void parseScrapeResults(std::map<std::string, retData*>& scrapeResults);
+};
+
+void PrometheusMetrics::parseScrapeResults(
+    std::map<std::string, retData*>& scrapeResults) {
+  for (auto const& target : scrapeResults) {
+    std::stringstream ss(target.second->content);
+    std::string dest;
+
+    while (std::getline(ss, dest)) {
+      if (dest[0] != '#') {
+        std::stringstream iss(dest);
+        std::string idest;
+        std::vector<std::string> metric;
+
+        while (std::getline(iss, idest, ' ')) {
+          if (dest != "") {
+            metric.push_back(idest);
+          }
+        }
+
+        if (metric.size() > 1) {
+          Row r;
+          r[col_target_name] = target.first,
+          r[col_timestamp] = std::to_string(
+              std::chrono::duration_cast<std::chrono::milliseconds>(
+                  std::chrono::system_clock::now().time_since_epoch())
+                  .count());
+          r[col_metric] = metric[0];
+          r[col_value] = metric[1];
+
+          m_rows.push_back(r);
+        }
+      }
+    }
+  }
+}
+
+std::map<std::string, retData*> PrometheusMetrics::scrapeTargets() {
+  std::map<std::string, retData*> results;
+  std::vector<CURL*> handles;
+  int stillRunning, repeat0fd;
+
+  // create a separate handle per target url
+  for (auto const& url : m_urls) {
+    CURL* handle = curl_easy_init();
+    CURLcode code = CURLE_FAILED_INIT;
+    retData* ret = new retData;
+
+    if (CURLE_OK ==
+            (code = curl_easy_setopt(handle, CURLOPT_URL, url.c_str())) &&
+        CURLE_OK == (code = curl_easy_setopt(
+                         handle, CURLOPT_WRITEFUNCTION, &writeCallback)) &&
+        CURLE_OK == (code = curl_easy_setopt(handle, CURLOPT_WRITEDATA, ret)) &&
+        CURLE_OK == (code = curl_easy_setopt(
+                         handle, CURLOPT_TIMEOUT, m_timeoutDurtionS))) {
+      handles.push_back(handle);
+      curl_multi_add_handle(m_multiHandle, handle);
+      results[url] = ret;
+
+    } else {
+      LOG(ERROR) << "failed on intialization of curl handle for '" << url
+                 << "' with error: " << curl_easy_strerror(code);
+      curl_easy_cleanup(handle);
+    }
+  }
+
+  // send async requests and watch for changes
+  // initiate multiperform action
+  curl_multi_perform(m_multiHandle, &stillRunning);
+
+  do {
+    CURLMcode status;
+    int numfds;
+
+    status = curl_multi_wait(
+        m_multiHandle, NULL, 0, m_timeoutDurtionS * 1000, &numfds);
+    if (status != CURLM_OK) {
+      // log error
+      LOG(ERROR) << "failed on curl_multi_wait: "
+                 << curl_multi_strerror(status);
+      break;
+    }
+    /* From libcurl docs:
+      'numfds' being zero means either a timeout or no file descriptors to
+      wait for. Try timeout on first occurrence, then assume no file
+      descriptors and no file descriptors to wait for means wait for 100
+      milliseconds. */
+    if (!numfds) {
+      repeat0fd++;
+
+      if (repeat0fd > 1) {
+        wait(100);
+      }
+
+    } else {
+      repeat0fd = 0;
+    }
+
+    curl_multi_perform(m_multiHandle, &stillRunning);
+
+  } while (stillRunning);
+
+  // clean up handles
+  for (auto& handle : handles) {
+    curl_multi_remove_handle(m_multiHandle, handle);
+    curl_easy_cleanup(handle);
+  }
+
+  return results;
+}
+
+QueryData& PrometheusMetrics::queryPrometheusTargets() {
+  std::map<std::string, retData*> scrapeResults(scrapeTargets());
+
+  parseScrapeResults(scrapeResults);
+
+  // free heap mem
+  for (auto& target : scrapeResults) {
+    delete target.second;
+  }
+
+  return m_rows;
+}
+
+QueryData genPrometheusMetrics(QueryContext& context) {
+  QueryData result;
+  // get urls from config
+  auto parser = Config::getParser("prometheus_targets");
+  if (parser == nullptr || parser.get() == nullptr) {
+    return result;
+  }
+
+  const auto& config = parser->getData().get_child(configParserRootKey);
+
+  if (config.count("urls") == 0) {
+    return result;
+  }
+
+  const auto& urls = config.get_child("urls");
+  std::vector<std::string> iurls;
+  for (const auto& url : urls) {
+    if (!url.first.empty()) {
+      return result;
+    }
+
+    iurls.push_back(url.second.data());
+  }
+
+  PrometheusMetrics pm(iurls);
+
+  result = pm.queryPrometheusTargets();
+
+  return result;
+}
+}
+}

--- a/osquery/tables/applications/posix/prometheus_metrics.cpp
+++ b/osquery/tables/applications/posix/prometheus_metrics.cpp
@@ -7,33 +7,21 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
-
-#include <chrono>
 #include <iostream>
 #include <map>
 #include <sstream>
 #include <string>
 #include <vector>
 
-#include <curl/curl.h>
-
 #include <osquery/config.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 
+#include <osquery/tables/applications/posix/prometheus_metrics.h>
 #include <osquery/tables/applications/posix/prometheus_metrics_utils.h>
 
 namespace osquery {
 namespace tables {
-const std::string col_target_name = "target_name";
-const std::string col_metric = "metric_name";
-const std::string col_value = "metric_value";
-const std::string col_timestamp = "timestamp";
-
-struct retData {
-  int size;
-  std::string content;
-};
 
 #ifdef _WIN32
 inline void wait(int x) {
@@ -51,6 +39,9 @@ size_t writeCallback(void* contents, size_t size, size_t nmemb, void* userp) {
   size_t realSize = size * nmemb;
   struct retData* payload = (struct retData*)userp;
 
+  payload->timestampMS = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::system_clock::now().time_since_epoch());
+
   char* cContents = (char*)contents;
   for (size_t i = 0; i < realSize; i++) {
     payload->content.push_back(cContents[i]);
@@ -61,34 +52,12 @@ size_t writeCallback(void* contents, size_t size, size_t nmemb, void* userp) {
   return realSize;
 }
 
-class PrometheusMetrics {
- public:
-  PrometheusMetrics(std::vector<std::string> urls, long timeoutDurationS = 1L)
-      : m_urls(urls),
-        m_multiHandle(curl_multi_init()),
-        m_timeoutDurtionS(timeoutDurationS) {}
-
-  ~PrometheusMetrics() {
-    curl_multi_cleanup(m_multiHandle);
-  }
-
-  QueryData& queryPrometheusTargets();
-
- private:
-  QueryData m_rows;
-  std::vector<std::string> m_urls;
-  CURLM* m_multiHandle;
-  long m_timeoutDurtionS;
-
-  std::map<std::string, retData*> scrapeTargets();
-  void parseScrapeResults(std::map<std::string, retData*>& scrapeResults);
-};
-
 void PrometheusMetrics::parseScrapeResults(
     std::map<std::string, retData*>& scrapeResults) {
   for (auto const& target : scrapeResults) {
     std::stringstream ss(target.second->content);
     std::string dest;
+    std::string ts(std::to_string(target.second->timestampMS.count()));
 
     while (std::getline(ss, dest)) {
       if (dest[0] != '#') {
@@ -104,15 +73,12 @@ void PrometheusMetrics::parseScrapeResults(
 
         if (metric.size() > 1) {
           Row r;
-          r[col_target_name] = target.first,
-          r[col_timestamp] = std::to_string(
-              std::chrono::duration_cast<std::chrono::milliseconds>(
-                  std::chrono::system_clock::now().time_since_epoch())
-                  .count());
+          r[col_target_name] = target.first;
+          r[col_timestamp] = ts;
           r[col_metric] = metric[0];
           r[col_value] = metric[1];
 
-          m_rows.push_back(r);
+          rows_.push_back(r);
         }
       }
     }
@@ -125,7 +91,7 @@ std::map<std::string, retData*> PrometheusMetrics::scrapeTargets() {
   int stillRunning, repeat0fd;
 
   // create a separate handle per target url
-  for (auto const& url : m_urls) {
+  for (auto const& url : urls_) {
     CURL* handle = curl_easy_init();
     CURLcode code = CURLE_FAILED_INIT;
     retData* ret = new retData;
@@ -136,9 +102,9 @@ std::map<std::string, retData*> PrometheusMetrics::scrapeTargets() {
                          handle, CURLOPT_WRITEFUNCTION, &writeCallback)) &&
         CURLE_OK == (code = curl_easy_setopt(handle, CURLOPT_WRITEDATA, ret)) &&
         CURLE_OK == (code = curl_easy_setopt(
-                         handle, CURLOPT_TIMEOUT, m_timeoutDurtionS))) {
+                         handle, CURLOPT_TIMEOUT, timeoutDurtionS_))) {
       handles.push_back(handle);
-      curl_multi_add_handle(m_multiHandle, handle);
+      curl_multi_add_handle(multiHandle_, handle);
       results[url] = ret;
 
     } else {
@@ -150,14 +116,14 @@ std::map<std::string, retData*> PrometheusMetrics::scrapeTargets() {
 
   // send async requests and watch for changes
   // initiate multiperform action
-  curl_multi_perform(m_multiHandle, &stillRunning);
+  curl_multi_perform(multiHandle_, &stillRunning);
 
   do {
     CURLMcode status;
     int numfds;
 
     status = curl_multi_wait(
-        m_multiHandle, NULL, 0, m_timeoutDurtionS * 1000, &numfds);
+        multiHandle_, NULL, 0, timeoutDurtionS_ * 1000, &numfds);
     if (status != CURLM_OK) {
       // log error
       LOG(ERROR) << "failed on curl_multi_wait: "
@@ -180,13 +146,13 @@ std::map<std::string, retData*> PrometheusMetrics::scrapeTargets() {
       repeat0fd = 0;
     }
 
-    curl_multi_perform(m_multiHandle, &stillRunning);
+    curl_multi_perform(multiHandle_, &stillRunning);
 
   } while (stillRunning);
 
   // clean up handles
   for (auto& handle : handles) {
-    curl_multi_remove_handle(m_multiHandle, handle);
+    curl_multi_remove_handle(multiHandle_, handle);
     curl_easy_cleanup(handle);
   }
 
@@ -203,7 +169,7 @@ QueryData& PrometheusMetrics::queryPrometheusTargets() {
     delete target.second;
   }
 
-  return m_rows;
+  return rows_;
 }
 
 QueryData genPrometheusMetrics(QueryContext& context) {

--- a/osquery/tables/applications/posix/prometheus_metrics.h
+++ b/osquery/tables/applications/posix/prometheus_metrics.h
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include <osquery/tables.h>
+
+#include <curl/curl.h>
+
+namespace osquery {
+namespace tables {
+
+const std::string col_target_name = "target_name";
+const std::string col_metric = "metric_name";
+const std::string col_value = "metric_value";
+const std::string col_timestamp = "timestamp_ms";
+
+struct retData {
+  int size;
+  std::string content;
+  std::chrono::milliseconds timestampMS;
+};
+
+typedef std::map<std::string, retData*> scrapeResults;
+
+class PrometheusMetrics {
+ public:
+  PrometheusMetrics(std::vector<std::string> urls, long timeoutDurationS = 1L)
+      : urls_(urls),
+        multiHandle_(curl_multi_init()),
+        timeoutDurtionS_(timeoutDurationS) {}
+
+  virtual ~PrometheusMetrics() {
+    curl_multi_cleanup(multiHandle_);
+  }
+
+  QueryData& queryPrometheusTargets();
+
+ protected:
+  virtual std::map<std::string, retData*> scrapeTargets();
+
+ private:
+  std::vector<std::string> urls_;
+  QueryData rows_;
+  CURLM* multiHandle_;
+  long timeoutDurtionS_;
+
+  void parseScrapeResults(std::map<std::string, retData*>& scrapeResults);
+};
+}
+}

--- a/osquery/tables/applications/posix/prometheus_metrics_utils.cpp
+++ b/osquery/tables/applications/posix/prometheus_metrics_utils.cpp
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <osquery/config.h>
+#include <osquery/logger.h>
+
+#include <osquery/tables/applications/posix/prometheus_metrics_utils.h>
+
+namespace osquery {
+
+Status PrometheusMetricsConfigParserPlugin::setUp() {
+  data_.put_child(configParserRootKey, pt::ptree());
+  return Status(0, "OK");
+}
+
+Status PrometheusMetricsConfigParserPlugin::update(const std::string& source,
+                                                   const ParserConfig& config) {
+  if (config.count(configParserRootKey) > 0) {
+    data_ = pt::ptree();
+    data_.put_child(configParserRootKey, config.at(configParserRootKey));
+  }
+
+  return Status(0, "OK");
+}
+
+REGISTER(PrometheusMetricsConfigParserPlugin,
+         "config_parser",
+         "prometheus_targets");
+}

--- a/osquery/tables/applications/posix/prometheus_metrics_utils.h
+++ b/osquery/tables/applications/posix/prometheus_metrics_utils.h
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2015, Welsey Shields
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+#include <string>
+#include <vector>
+
+#include <osquery/config.h>
+
+namespace pt = boost::property_tree;
+
+namespace osquery {
+
+const std::string configParserRootKey("prometheus_targets");
+
+class PrometheusMetricsConfigParserPlugin : public ConfigParserPlugin {
+ public:
+  std::vector<std::string> keys() const override {
+    return {configParserRootKey};
+  }
+
+  Status setUp() override;
+  Status update(const std::string& source, const ParserConfig& config) override;
+};
+}

--- a/osquery/tables/applications/posix/tests/prometheus_metrics_tests.cpp
+++ b/osquery/tables/applications/posix/tests/prometheus_metrics_tests.cpp
@@ -1,0 +1,455 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+#include <gtest/gtest.h>
+
+#include <osquery/tables/applications/posix/prometheus_metrics.h>
+
+namespace osquery {
+namespace tables {
+
+class TestPM : public PrometheusMetrics {
+ public:
+  std::map<std::string, retData*> scrapeResults_;
+  TestPM(std::vector<std::string> urls) : PrometheusMetrics(urls) {}
+
+ protected:
+  virtual std::map<std::string, retData*> scrapeTargets() {
+    return scrapeResults_;
+  }
+};
+
+inline bool comparePMRow(Row& row1, Row& row2) {
+  return (row1[col_target_name] + row1[col_metric]) <
+         (row2[col_target_name] + row2[col_metric]);
+}
+
+void validatePMTest(PrometheusMetrics& pm, QueryData& expected) {
+  QueryData got = pm.queryPrometheusTargets();
+
+  ASSERT_EQ(got.size(), expected.size());
+
+  // sort rows
+  std::sort(got.begin(), got.end(), comparePMRow);
+  std::sort(expected.begin(), expected.end(), comparePMRow);
+
+  for (size_t i = 0; i < got.size(); i++) {
+    EXPECT_TRUE(expected[i][col_target_name] == got[i][col_target_name]);
+    EXPECT_TRUE(expected[i][col_metric] == got[i][col_metric]);
+    EXPECT_TRUE(expected[i][col_value] == got[i][col_value]);
+    EXPECT_TRUE(expected[i][col_timestamp] == got[i][col_timestamp]);
+  }
+}
+
+class PrometheusMetricsTest : public ::testing::Test {};
+
+TEST_F(PrometheusMetricsTest, no_target_urls) {
+  std::vector<std::string> urls;
+  PrometheusMetrics pm(urls);
+
+  QueryData expected;
+
+  validatePMTest(pm, expected);
+}
+
+TEST_F(PrometheusMetricsTest, happy_path_0_metrics) {
+  /* Initialize stubbed scrape results.
+   Must allocate on heap b/c queryPrometheusTargets assumes so and calls
+  delete. */
+  std::chrono::milliseconds now(
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::system_clock::now().time_since_epoch()));
+
+  retData* r0 = new retData{0, "", now};
+  scrapeResults sr = {{"example1.com", r0}};
+
+  // Initialize expected output.
+  QueryData expected;
+
+  // Construct url vector for obj instantiation.
+  std::vector<std::string> urls;
+  for (const auto& ea : sr) {
+    urls.push_back(ea.first);
+  }
+
+  // Initialize TestPM instance
+  TestPM pm(urls);
+  pm.scrapeResults_ = sr;
+
+  validatePMTest(pm, expected);
+}
+
+TEST_F(PrometheusMetricsTest, happy_path_1_metric) {
+  /* Initialize stubbed scrape results.
+   Must allocate on heap b/c queryPrometheusTargets assumes so and calls
+  delete. */
+  std::chrono::milliseconds now(
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::system_clock::now().time_since_epoch()));
+  retData* r0 = new retData{
+      500, "# some comment\nprocess_virtual_memory_bytes 1.3934592e+07", now};
+  scrapeResults sr = {{"example1.com", r0}};
+
+  // Initialize expected output.
+  QueryData expected = {
+      {{col_target_name, "example1.com"},
+       {col_metric, "process_virtual_memory_bytes"},
+       {col_value, "1.3934592e+07"},
+       {col_timestamp, std::to_string(now.count())}},
+  };
+
+  // Construct url vector for obj instantiation.
+  std::vector<std::string> urls;
+  for (const auto& ea : sr) {
+    urls.push_back(ea.first);
+  }
+
+  // Initialize TestPM instance
+  TestPM pm(urls);
+  pm.scrapeResults_ = sr;
+
+  validatePMTest(pm, expected);
+}
+
+TEST_F(PrometheusMetricsTest, happy_path_10_metrics_1_target) {
+  /* Initialize stubbed scrape results.
+   Must allocate on heap b/c queryPrometheusTargets assumes so and calls
+  delete. */
+  std::chrono::milliseconds now(
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::system_clock::now().time_since_epoch()));
+  std::string nowStr(std::to_string(now.count()));
+
+  retData* r0 = new retData{
+      500,
+      "# HELP node_vmstat_unevictable_pgs_stranded /proc/vmstat information "
+      "field unevictable_pgs_stranded.\n# TYPE "
+      "node_vmstat_unevictable_pgs_stranded "
+      "untyped\nnode_vmstat_unevictable_pgs_stranded 0\n# HELP "
+      "node_vmstat_workingset_activate /proc/vmstat information field "
+      "workingset_activate.\n# TYPE node_vmstat_workingset_activate "
+      "untyped\nnode_vmstat_workingset_activate 0\n# HELP "
+      "node_vmstat_workingset_nodereclaim /proc/vmstat information field "
+      "workingset_nodereclaim.\n# TYPE node_vmstat_workingset_nodereclaim "
+      "untyped\nnode_vmstat_workingset_nodereclaim 0\n# HELP "
+      "node_vmstat_workingset_refault /proc/vmstat information field "
+      "workingset_refault.\n# TYPE node_vmstat_workingset_refault "
+      "untyped\nnode_vmstat_workingset_refault 0\n# HELP "
+      "process_cpu_seconds_total Total user and system CPU time spent in "
+      "seconds.\n# TYPE process_cpu_seconds_total "
+      "counter\nprocess_cpu_seconds_total 0.25\n# HELP process_max_fds Maximum "
+      "number of open file descriptors.\n# TYPE process_max_fds "
+      "gauge\nprocess_max_fds 1.048576e+06\n# HELP process_open_fds Number of "
+      "open file descriptors.\n# TYPE process_open_fds gauge\nprocess_open_fds "
+      "7\n# HELP process_resident_memory_bytes Resident memory size in "
+      "bytes.\n# TYPE process_resident_memory_bytes "
+      "gauge\nprocess_resident_memory_bytes 1.0170368e+07\n# HELP "
+      "process_start_time_seconds Start time of the process since unix epoch "
+      "in seconds.\n# TYPE process_start_time_seconds "
+      "gauge\nprocess_start_time_seconds 1.48475733855e+09\n# HELP "
+      "process_virtual_memory_bytes Virtual memory size in bytes.\n# TYPE "
+      "process_virtual_memory_bytes gauge\nprocess_virtual_memory_bytes "
+      "1.3934592e+07\n",
+      now,
+  };
+  scrapeResults sr = {{"example1.com", r0}};
+
+  // Initialize expected output.
+  QueryData expected = {
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "node_vmstat_unevictable_pgs_stranded"},
+          {col_value, "0"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "node_vmstat_workingset_activate"},
+          {col_value, "0"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "node_vmstat_workingset_nodereclaim"},
+          {col_value, "0"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "node_vmstat_workingset_refault"},
+          {col_value, "0"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "process_cpu_seconds_total"},
+          {col_value, "0.25"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "process_max_fds"},
+          {col_value, "1.048576e+06"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "process_open_fds"},
+          {col_value, "7"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "process_resident_memory_bytes"},
+          {col_value, "1.0170368e+07"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "process_start_time_seconds"},
+          {col_value, "1.48475733855e+09"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "process_virtual_memory_bytes"},
+          {col_value, "1.3934592e+07"},
+          {col_timestamp, nowStr},
+      },
+  };
+
+  // Construct url vector for obj instantiation.
+  std::vector<std::string> urls;
+  for (const auto& ea : sr) {
+    urls.push_back(ea.first);
+  }
+
+  // Initialize TestPM instance
+  TestPM pm(urls);
+  pm.scrapeResults_ = sr;
+
+  validatePMTest(pm, expected);
+}
+
+TEST_F(PrometheusMetricsTest, happy_path_10_metrics_2_targets) {
+  /* Initialize stubbed scrape results.
+   Must allocate on heap b/c queryPrometheusTargets assumes so and calls
+  delete. */
+  std::chrono::milliseconds now(
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::system_clock::now().time_since_epoch()));
+
+  std::string nowStr(std::to_string(now.count()));
+
+  retData* r0 = new retData{
+      500,
+      "# HELP node_vmstat_unevictable_pgs_stranded /proc/vmstat information "
+      "field unevictable_pgs_stranded.\n# TYPE "
+      "node_vmstat_unevictable_pgs_stranded "
+      "untyped\nnode_vmstat_unevictable_pgs_stranded 0\n# HELP "
+      "node_vmstat_workingset_activate /proc/vmstat information field "
+      "workingset_activate.\n# TYPE node_vmstat_workingset_activate "
+      "untyped\nnode_vmstat_workingset_activate 0\n# HELP "
+      "node_vmstat_workingset_nodereclaim /proc/vmstat information field "
+      "workingset_nodereclaim.\n# TYPE node_vmstat_workingset_nodereclaim "
+      "untyped\nnode_vmstat_workingset_nodereclaim 0\n# HELP "
+      "node_vmstat_workingset_refault /proc/vmstat information field "
+      "workingset_refault.\n# TYPE node_vmstat_workingset_refault "
+      "untyped\nnode_vmstat_workingset_refault 0\n# HELP "
+      "process_cpu_seconds_total Total user and system CPU time spent in "
+      "seconds.\n# TYPE process_cpu_seconds_total "
+      "counter\nprocess_cpu_seconds_total 0.25\n# HELP process_max_fds Maximum "
+      "number of open file descriptors.\n# TYPE process_max_fds "
+      "gauge\nprocess_max_fds 1.048576e+06\n# HELP process_open_fds Number of "
+      "open file descriptors.\n# TYPE process_open_fds gauge\nprocess_open_fds "
+      "7\n# HELP process_resident_memory_bytes Resident memory size in "
+      "bytes.\n# TYPE process_resident_memory_bytes "
+      "gauge\nprocess_resident_memory_bytes 1.0170368e+07\n# HELP "
+      "process_start_time_seconds Start time of the process since unix epoch "
+      "in seconds.\n# TYPE process_start_time_seconds "
+      "gauge\nprocess_start_time_seconds 1.48475733855e+09\n# HELP "
+      "process_virtual_memory_bytes Virtual memory size in bytes.\n# TYPE "
+      "process_virtual_memory_bytes gauge\nprocess_virtual_memory_bytes "
+      "1.3934592e+07\n",
+      now,
+  };
+  retData* r1 = new retData{
+      500,
+      "# HELP node_vmstat_unevictable_pgs_stranded /proc/vmstat information "
+      "field unevictable_pgs_stranded.\n# TYPE "
+      "node_vmstat_unevictable_pgs_stranded "
+      "untyped\nnode_vmstat_unevictable_pgs_stranded2 0\n# HELP "
+      "node_vmstat_workingset_activate /proc/vmstat information field "
+      "workingset_activate.\n# TYPE node_vmstat_workingset_activate "
+      "untyped\nnode_vmstat_workingset_activate2 0\n# HELP "
+      "node_vmstat_workingset_nodereclaim /proc/vmstat information field "
+      "workingset_nodereclaim.\n# TYPE node_vmstat_workingset_nodereclaim "
+      "untyped\nnode_vmstat_workingset_nodereclaim2 0\n# HELP "
+      "node_vmstat_workingset_refault /proc/vmstat information field "
+      "workingset_refault.\n# TYPE node_vmstat_workingset_refault "
+      "untyped\nnode_vmstat_workingset_refault2 0\n# HELP "
+      "process_cpu_seconds_total Total user and system CPU time spent in "
+      "seconds.\n# TYPE process_cpu_seconds_total "
+      "counter\nprocess_cpu_seconds_total2 0.25\n# HELP process_max_fds "
+      "Maximum "
+      "number of open file descriptors.\n# TYPE process_max_fds "
+      "gauge\nprocess_max_fds2 1.048576e+06\n# HELP process_open_fds Number of "
+      "open file descriptors.\n# TYPE process_open_fds "
+      "gauge\nprocess_open_fds2 "
+      "7\n# HELP process_resident_memory_bytes Resident memory size in "
+      "bytes.\n# TYPE process_resident_memory_bytes "
+      "gauge\nprocess_resident_memory_bytes2 1.0170368e+07\n# HELP "
+      "process_start_time_seconds Start time of the process since unix epoch "
+      "in seconds.\n# TYPE process_start_time_seconds "
+      "gauge\nprocess_start_time_seconds2 1.48475733855e+09\n# HELP "
+      "process_virtual_memory_bytes Virtual memory size in bytes.\n# TYPE "
+      "process_virtual_memory_bytes gauge\nprocess_virtual_memory_bytes2 "
+      "1.3934592e+07\n",
+      now,
+  };
+  scrapeResults sr = {{"example1.com", r0}, {"example2.com", r1}};
+
+  // Initialize expected output.
+  QueryData expected = {
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "node_vmstat_unevictable_pgs_stranded"},
+          {col_value, "0"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "node_vmstat_workingset_activate"},
+          {col_value, "0"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "node_vmstat_workingset_nodereclaim"},
+          {col_value, "0"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "node_vmstat_workingset_refault"},
+          {col_value, "0"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "process_cpu_seconds_total"},
+          {col_value, "0.25"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "process_max_fds"},
+          {col_value, "1.048576e+06"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "process_open_fds"},
+          {col_value, "7"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "process_resident_memory_bytes"},
+          {col_value, "1.0170368e+07"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "process_start_time_seconds"},
+          {col_value, "1.48475733855e+09"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example1.com"},
+          {col_metric, "process_virtual_memory_bytes"},
+          {col_value, "1.3934592e+07"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example2.com"},
+          {col_metric, "node_vmstat_unevictable_pgs_stranded2"},
+          {col_value, "0"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example2.com"},
+          {col_metric, "node_vmstat_workingset_activate2"},
+          {col_value, "0"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example2.com"},
+          {col_metric, "node_vmstat_workingset_nodereclaim2"},
+          {col_value, "0"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example2.com"},
+          {col_metric, "node_vmstat_workingset_refault2"},
+          {col_value, "0"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example2.com"},
+          {col_metric, "process_cpu_seconds_total2"},
+          {col_value, "0.25"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example2.com"},
+          {col_metric, "process_max_fds2"},
+          {col_value, "1.048576e+06"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example2.com"},
+          {col_metric, "process_open_fds2"},
+          {col_value, "7"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example2.com"},
+          {col_metric, "process_resident_memory_bytes2"},
+          {col_value, "1.0170368e+07"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example2.com"},
+          {col_metric, "process_start_time_seconds2"},
+          {col_value, "1.48475733855e+09"},
+          {col_timestamp, nowStr},
+      },
+      {
+          {col_target_name, "example2.com"},
+          {col_metric, "process_virtual_memory_bytes2"},
+          {col_value, "1.3934592e+07"},
+          {col_timestamp, nowStr},
+      },
+  };
+
+  // Construct url vector for obj instantiation.
+  std::vector<std::string> urls;
+  for (const auto& ea : sr) {
+    urls.push_back(ea.first);
+  }
+
+  // Initialize TestPM instance
+  TestPM pm(urls);
+  pm.scrapeResults_ = sr;
+
+  validatePMTest(pm, expected);
+}
+}
+}

--- a/specs/posix/prometheus_metrics.table
+++ b/specs/posix/prometheus_metrics.table
@@ -1,0 +1,9 @@
+table_name("prometheus_metrics")
+description("Network interfaces and relevant metadata.")
+schema([
+    Column("target_name", TEXT, "Address of prometheus target"),
+    Column("metric_name", TEXT, "Name of collected Prometheus metric"),
+    Column("metric_value", DOUBLE, "Value of collected Prometheus metric"),
+    Column("timestamp", BIGINT, "Unix timestamp of collected data in MS"),
+])
+implementation("applications/prometheus_metrics@genPrometheusMetrics")

--- a/specs/posix/prometheus_metrics.table
+++ b/specs/posix/prometheus_metrics.table
@@ -4,6 +4,6 @@ schema([
     Column("target_name", TEXT, "Address of prometheus target"),
     Column("metric_name", TEXT, "Name of collected Prometheus metric"),
     Column("metric_value", DOUBLE, "Value of collected Prometheus metric"),
-    Column("timestamp", BIGINT, "Unix timestamp of collected data in MS"),
+    Column("timestamp_ms", BIGINT, "Unix timestamp of collected data in MS"),
 ])
 implementation("applications/prometheus_metrics@genPrometheusMetrics")


### PR DESCRIPTION
- Table consists of metrics scraped from configured target urls, where the timestamp column/field is a unix timestamp in MS of the time of query.
- In order to use the table, you must pass in a JSON config file consisting of target urls in this format
```bash
osqueryi --config_path ./example.json
```

JSON sample:
```json
{
  "prometheus_targets": {
    "urls": [
      "http://localhost:9100/metrics",
      "http://localhost:9101/metrics"
    ]
  }
}
```